### PR TITLE
Add go.sum and fix dependency version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,13 @@
 module telegram-chatgpt-bot
 
-go 1.18
+go 1.23.0
+
+toolchain go1.24.3
 
 require (
-    github.com/boltdb/bolt v1.3.1
-    github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.8.0
-    github.com/sashabaranov/go-openai v1.8.0
+	github.com/boltdb/bolt v1.3.1
+	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
+	github.com/sashabaranov/go-openai v1.8.0
 )
+
+require golang.org/x/sys v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
+github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
+github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
+github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
+github.com/sashabaranov/go-openai v1.8.0 h1:IZrNK/gGqxtp0j19F4NLGbmfoOkyDpM3oC9i/tv9bBM=
+github.com/sashabaranov/go-openai v1.8.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
+golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=


### PR DESCRIPTION
## Summary
- update go.mod to available telegram bot API version
- run `go mod tidy` to generate go.sum

## Testing
- `go mod tidy`
- `go vet ./...` *(fails: command timed out / not executed? we aborted due to indefinite hang)*

------
https://chatgpt.com/codex/tasks/task_e_688bf54d30a88323aa5427d6c69507cb