### PR TITLE
Use AWS Secrets Manager for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ A `Dockerfile` and `docker-compose.yml` are included for container-based deploym
 docker build -t tgptbot .
 ```
 
-2. Copy the sample environment file and edit the values:
+2. (Optional) For local testing copy the sample environment file and edit the values:
 
 ```bash
 cp env.example .env
@@ -96,5 +96,22 @@ docker-compose up -d
 ```
 
 The Bolt database will be stored under `data/` on the host.
+
+## Deployment with AWS Secrets Manager
+
+When running on an EC2 instance the bot can read its credentials directly from
+AWS Secrets Manager instead of a local `.env` file. The helper script
+`start-compose.sh` retrieves the secrets and starts the container using
+Docker Compose. Set the secret names via the environment variables
+`BOT_TOKEN_SECRET_ID` and `MASTER_KEY_SECRET_ID` and execute the script:
+
+```bash
+export BOT_TOKEN_SECRET_ID="my-bot-token-secret"
+export MASTER_KEY_SECRET_ID="my-master-key-secret"
+./start-compose.sh
+```
+
+The script requires `aws` CLI credentials to be available (for example via the
+instance's IAM role).
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3'
 services:
   bot:
     build: .
-    env_file: .env
+    environment:
+      - BOT_TOKEN=${BOT_TOKEN}
+      - MASTER_KEY=${MASTER_KEY}
     volumes:
       - ./data:/data

--- a/start-compose.sh
+++ b/start-compose.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+BOT_TOKEN=$(aws secretsmanager get-secret-value --secret-id "$BOT_TOKEN_SECRET_ID" --query SecretString --output text)
+MASTER_KEY=$(aws secretsmanager get-secret-value --secret-id "$MASTER_KEY_SECRET_ID" --query SecretString --output text)
+
+export BOT_TOKEN MASTER_KEY
+exec docker-compose up -d
+


### PR DESCRIPTION
## Summary
- configure `docker-compose.yml` to use BOT_TOKEN and MASTER_KEY from the host
- document using AWS Secrets Manager with helper script
- add `start-compose.sh` script to fetch secrets and start compose

## Testing
- `go build ./...` *(fails: msg.MessageThreadID undefined)*

------
https://chatgpt.com/codex/tasks/task_e_688c999d6b548323ba30c8caf2bc4cd1