### PR TITLE
Fix MessageThreadID build issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.3
 
 require (
 	github.com/boltdb/bolt v1.3.1
-	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
+	github.com/go-telegram/bot v1.16.0
 	github.com/sashabaranov/go-openai v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
-github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
-github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
+github.com/go-telegram/bot v1.16.0 h1:s6aDgM9whapccMD70gt27BPG3E7R8a6FaWw+8UsRYog=
+github.com/go-telegram/bot v1.16.0/go.mod h1:i2TRs7fXWIeaceF3z7KzsMt/he0TwkVC680mvdTFYeM=
 github.com/sashabaranov/go-openai v1.8.0 h1:IZrNK/gGqxtp0j19F4NLGbmfoOkyDpM3oC9i/tv9bBM=
 github.com/sashabaranov/go-openai v1.8.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -1,126 +1,140 @@
 package handler
 
 import (
-	"context"
-	"fmt"
-	"log"
-	"strings"
+    "context"
+    "fmt"
+    "log"
+    "strings"
 
-	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
-	openai "github.com/sashabaranov/go-openai"
+    tg "github.com/go-telegram/bot"
+    "github.com/go-telegram/bot/models"
+    openai "github.com/sashabaranov/go-openai"
 
-	"telegram-chatgpt-bot/internal/crypt"
-	"telegram-chatgpt-bot/internal/storage"
+    "telegram-chatgpt-bot/internal/crypt"
+    "telegram-chatgpt-bot/internal/storage"
 )
 
 var pendingAuth = map[int64]string{}
 
 // HandleUpdate processes a Telegram update.
-func HandleUpdate(bot *tgbotapi.BotAPI, upd tgbotapi.Update) {
-	if upd.Message == nil {
-		return
-	}
-	msg := upd.Message
-	chatID := msg.Chat.ID
-	topicID := msg.MessageThreadID
+func HandleUpdate(ctx context.Context, b *tg.Bot, upd *models.Update) {
+    if upd.Message == nil {
+        return
+    }
+    msg := upd.Message
+    chatID := msg.Chat.ID
+    topicID := msg.MessageThreadID
 
-	// Command handlers
-	if msg.IsCommand() {
-		switch msg.Command() {
-		case "authproject":
-			args := msg.CommandArguments()
-			if args == "" {
-				bot.Send(tgbotapi.NewMessage(chatID, "Usage: /authproject <projectName>"))
-				return
-			}
-			prompt := tgbotapi.NewMessage(chatID, fmt.Sprintf("Please send me the OpenAI API key for project '%s' now.", args))
-			bot.Send(prompt)
-			pendingAuth[msg.From.ID] = args
-			return
+    // Command handlers
+    if cmd, args, ok := parseCommand(msg); ok {
+        switch cmd {
+        case "authproject":
+            if args == "" {
+                b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: "Usage: /authproject <projectName>"})
+                return
+            }
+            prompt := fmt.Sprintf("Please send me the OpenAI API key for project '%s' now.", args)
+            b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: prompt})
+            pendingAuth[msg.From.ID] = args
+            return
 
-		case "settopic":
-			if topicID == 0 {
-				bot.Send(tgbotapi.NewMessage(chatID, "Must be called in a topic thread."))
-				return
-			}
-			proj := msg.CommandArguments()
-			if proj == "" {
-				bot.Send(tgbotapi.NewMessage(chatID, "Usage: /settopic <projectName>"))
-				return
-			}
-			if _, err := storage.LoadProject(proj); err != nil {
-				bot.Send(tgbotapi.NewMessage(chatID, "Project not found."))
-				return
-			}
-			if err := storage.MapTopic(chatID, topicID, proj); err != nil {
-				bot.Send(tgbotapi.NewMessage(chatID, "Failed to map topic: "+err.Error()))
-				return
-			}
-			bot.Send(tgbotapi.NewMessage(chatID, "Topic mapped to project '"+proj+"'."))
-			return
+        case "settopic":
+            if topicID == 0 {
+                b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: "Must be called in a topic thread."})
+                return
+            }
+            proj := args
+            if proj == "" {
+                b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: "Usage: /settopic <projectName>"})
+                return
+            }
+            if _, err := storage.LoadProject(proj); err != nil {
+                b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: "Project not found."})
+                return
+            }
+            if err := storage.MapTopic(chatID, topicID, proj); err != nil {
+                b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: "Failed to map topic: " + err.Error()})
+                return
+            }
+            b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: "Topic mapped to project '" + proj + "'."})
+            return
 
-		case "unsettopic":
-			if topicID == 0 {
-				bot.Send(tgbotapi.NewMessage(chatID, "Must be in a topic thread."))
-				return
-			}
-			if err := storage.UnmapTopic(chatID, topicID); err != nil {
-				bot.Send(tgbotapi.NewMessage(chatID, "Failed to unmap: "+err.Error()))
-				return
-			}
-			bot.Send(tgbotapi.NewMessage(chatID, "Topic unmapped."))
-			return
+        case "unsettopic":
+            if topicID == 0 {
+                b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: "Must be in a topic thread."})
+                return
+            }
+            if err := storage.UnmapTopic(chatID, topicID); err != nil {
+                b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: "Failed to unmap: " + err.Error()})
+                return
+            }
+            b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: "Topic unmapped."})
+            return
 
-		case "listprojects":
-			projs, _ := storage.ListProjects()
-			bot.Send(tgbotapi.NewMessage(chatID, "Projects: "+strings.Join(projs, ", ")))
-			return
-		}
-	}
+        case "listprojects":
+            projs, _ := storage.ListProjects()
+            b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: "Projects: " + strings.Join(projs, ", ")})
+            return
+        }
+    }
 
-	if pendingProject, ok := pendingAuth[msg.From.ID]; ok && msg.Text != "" {
-		key := strings.TrimSpace(msg.Text)
-		enc, err := crypt.Encrypt(key)
-		delete(pendingAuth, msg.From.ID)
-		if err != nil {
-			bot.Send(tgbotapi.NewMessage(chatID, "Encryption error: "+err.Error()))
-			return
-		}
-		if err := storage.SaveProject(pendingProject, enc); err != nil {
-			bot.Send(tgbotapi.NewMessage(chatID, "Save error: "+err.Error()))
-			return
-		}
-		bot.Send(tgbotapi.NewMessage(chatID, "Project '"+pendingProject+"' saved."))
-		return
-	}
+    if pendingProject, ok := pendingAuth[msg.From.ID]; ok && msg.Text != "" {
+        key := strings.TrimSpace(msg.Text)
+        enc, err := crypt.Encrypt(key)
+        delete(pendingAuth, msg.From.ID)
+        if err != nil {
+            b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: "Encryption error: " + err.Error()})
+            return
+        }
+        if err := storage.SaveProject(pendingProject, enc); err != nil {
+            b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: "Save error: " + err.Error()})
+            return
+        }
+        b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: "Project '" + pendingProject + "' saved."})
+        return
+    }
 
-	proj, err := storage.GetMappedProject(chatID, topicID)
-	if err != nil {
-		return
-	}
-	encKey, _ := storage.LoadProject(proj)
-	apiKey, err := crypt.Decrypt(encKey)
-	if err != nil {
-		log.Println("decrypt error:", err)
-		return
-	}
-	client := openai.NewClient(apiKey)
-	resp, err := client.CreateChatCompletion(
-		context.Background(),
-		openai.ChatCompletionRequest{
-			Model: openai.GPT3Dot5Turbo,
-			Messages: []openai.ChatCompletionMessage{
-				{Role: openai.ChatMessageRoleUser, Content: msg.Text},
-			},
-		},
-	)
-	if err != nil {
-		bot.Send(tgbotapi.NewMessage(chatID, "OpenAI error: "+err.Error()))
-		return
-	}
-	reply := resp.Choices[0].Message.Content
-	out := tgbotapi.NewMessage(chatID, reply)
-	out.ReplyToMessageID = msg.MessageID
-	out.MessageThreadID = topicID
-	bot.Send(out)
+    proj, err := storage.GetMappedProject(chatID, topicID)
+    if err != nil {
+        return
+    }
+    encKey, _ := storage.LoadProject(proj)
+    apiKey, err := crypt.Decrypt(encKey)
+    if err != nil {
+        log.Println("decrypt error:", err)
+        return
+    }
+    client := openai.NewClient(apiKey)
+    resp, err := client.CreateChatCompletion(
+        context.Background(),
+        openai.ChatCompletionRequest{
+            Model:    openai.GPT3Dot5Turbo,
+            Messages: []openai.ChatCompletionMessage{{Role: openai.ChatMessageRoleUser, Content: msg.Text}},
+        },
+    )
+    if err != nil {
+        b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, Text: "OpenAI error: " + err.Error()})
+        return
+    }
+    reply := resp.Choices[0].Message.Content
+    b.SendMessage(ctx, &tg.SendMessageParams{
+        ChatID:          chatID,
+        MessageThreadID: topicID,
+        Text:            reply,
+        ReplyParameters: &models.ReplyParameters{MessageID: msg.ID},
+    })
+}
+
+func parseCommand(msg *models.Message) (cmd, args string, ok bool) {
+    if msg.Text == "" {
+        return "", "", false
+    }
+    for _, e := range msg.Entities {
+        if e.Type == models.MessageEntityTypeBotCommand && e.Offset == 0 {
+            cmd = strings.TrimPrefix(msg.Text[:e.Length], "/")
+            args = strings.TrimSpace(msg.Text[e.Length:])
+            return cmd, args, true
+        }
+    }
+    return "", "", false
 }


### PR DESCRIPTION
## Summary
- Switched to the modern go-telegram/bot library and removed the local vendored copy of the older API, keeping dependencies clean
- Implemented bot initialization using the new library and logged the bot username via GetMe before starting event processing
- Reworked the update handler to use the new types and implemented command parsing manually, preserving MessageThreadID support for replies in topic threads


------
https://chatgpt.com/codex/tasks/task_e_688c9fb2a49083238d5269e3c3a304e0