### PR TITLE
Allow manual model entry for /setmodel command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ go build -o tgptbot ./cmd/tgptbot
   → register a new project.
 
 * `/setmodel <projectName>`
-  → choose the ChatGPT model for a project (defaults to ChatGPT 5).
+  → set the ChatGPT model for a project (defaults to ChatGPT 5). After running the command, the bot asks you to enter the model name.
 
 * `/listprojects` to see saved projects.
 


### PR DESCRIPTION
## Summary
- Prompt users to enter a model name after `/setmodel <project>` instead of showing inline buttons
- Persist entered model names per project
- Document manual model entry in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689841c213e483238d11ea746ae5da2e