### PR TITLE
Allow disabling message history

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ export TBOT_TELEGRAM_KEY="123…"
 export TBOT_CHATGPT_KEY="sk-..."
 export TBOT_MASTER_KEY="base64-32-bytes"
 export TBOT_ALLOWED_USER_IDS="12345,67890"
-export TBOT_HISTORY_LIMIT="10" # number of messages to keep in private chats
+export TBOT_HISTORY_LIMIT="10" # number of messages to keep in private chats (0 disables history)
 export LOG_LEVEL="info" # optional: debug, info, warn, error
 ```
 
@@ -120,7 +120,7 @@ export TBOT_TELEGRAM_KEY=$(echo "$SECRET_JSON" | jq -r '."tbot-telegram-access-t
 export TBOT_MASTER_KEY=$(echo "$SECRET_JSON" | jq -r '."tbot-master-key"')
 export TBOT_CHATGPT_KEY=$(echo "$SECRET_JSON" | jq -r '."tbot-chatgpt-key"')
 export TBOT_ALLOWED_USER_IDS=$(echo "$SECRET_JSON" | jq -r '."tbot-allowed-user-ids"')
-export TBOT_HISTORY_LIMIT=10
+export TBOT_HISTORY_LIMIT=10 # 0 disables history
 ```
 
 For local development you may still create a `.env` file from `env.example` and

--- a/env.example
+++ b/env.example
@@ -2,5 +2,6 @@ TBOT_TELEGRAM_KEY=
 TBOT_MASTER_KEY=
 TBOT_CHATGPT_KEY=
 TBOT_ALLOWED_USER_IDS=
+# TBOT_HISTORY_LIMIT controls message history in private chats; set to 0 to disable history
 TBOT_HISTORY_LIMIT=10
 LOG_LEVEL=

--- a/start-compose.sh
+++ b/start-compose.sh
@@ -10,6 +10,7 @@ TBOT_MASTER_KEY=$(jq -r '."tbot-master-key"' <<<"$SECRET_JSON")
 TBOT_CHATGPT_KEY=$(jq -r '."tbot-chatgpt-key"' <<<"$SECRET_JSON")
 TBOT_ALLOWED_USER_IDS=$(jq -r '."tbot-allowed-user-ids"' <<<"$SECRET_JSON")
 
+# Keep up to 10 messages in private chats; set to 0 to disable history
 TBOT_HISTORY_LIMIT=10
 
 export TBOT_TELEGRAM_KEY TBOT_MASTER_KEY TBOT_CHATGPT_KEY TBOT_ALLOWED_USER_IDS TBOT_HISTORY_LIMIT


### PR DESCRIPTION
## Summary
- allow TBOT_HISTORY_LIMIT=0 to disable storing and pruning chat history
- document how to disable history via TBOT_HISTORY_LIMIT

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68984c7fd9e08323968772ade5043c61