### PR TITLE
feat: add per-project message history

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ export TBOT_TELEGRAM_KEY="123…"
 export TBOT_CHATGPT_KEY="sk-..."
 export TBOT_MASTER_KEY="base64-32-bytes"
 export TBOT_ALLOWED_USER_IDS="12345,67890"
-export TBOT_HISTORY_LIMIT="10" # number of messages to keep in private chats (0 disables history)
 export LOG_LEVEL="info" # optional: debug, info, warn, error
 ```
 
@@ -62,6 +61,15 @@ go build -o tgptbot ./cmd/tgptbot
 
 * `/showrule <projectName>`
   → display the current instruction for a project.
+
+* `/history <projectName>`
+  → show current history limit and stored message count.
+
+* `/set-history-limit <projectName>`
+  → change how many messages are kept for the project (0 disables history).
+
+* `/clear-history <projectName>`
+  → remove all stored messages for the project (requires confirmation).
 
 * `/listprojects`
   → see saved projects.
@@ -120,7 +128,6 @@ export TBOT_TELEGRAM_KEY=$(echo "$SECRET_JSON" | jq -r '."tbot-telegram-access-t
 export TBOT_MASTER_KEY=$(echo "$SECRET_JSON" | jq -r '."tbot-master-key"')
 export TBOT_CHATGPT_KEY=$(echo "$SECRET_JSON" | jq -r '."tbot-chatgpt-key"')
 export TBOT_ALLOWED_USER_IDS=$(echo "$SECRET_JSON" | jq -r '."tbot-allowed-user-ids"')
-export TBOT_HISTORY_LIMIT=10 # 0 disables history
 ```
 
 For local development you may still create a `.env` file from `env.example` and
@@ -129,7 +136,7 @@ manually provide the values.
 3. Run the container with a persistent data directory:
 
 ```bash
-docker run -e TBOT_TELEGRAM_KEY -e TBOT_MASTER_KEY -e TBOT_CHATGPT_KEY -e TBOT_ALLOWED_USER_IDS -e TBOT_HISTORY_LIMIT -v $(pwd)/data:/data tgptbot
+docker run -e TBOT_TELEGRAM_KEY -e TBOT_MASTER_KEY -e TBOT_CHATGPT_KEY -e TBOT_ALLOWED_USER_IDS -v $(pwd)/data:/data tgptbot
 ```
 
 Alternatively start it with Docker Compose, which will inherit the environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       - TBOT_MASTER_KEY=${TBOT_MASTER_KEY:--ABSENT--}
       - TBOT_CHATGPT_KEY=${TBOT_CHATGPT_KEY:--ABSENT--}
       - TBOT_ALLOWED_USER_IDS=${TBOT_ALLOWED_USER_IDS:--ABSENT--}
-      - TBOT_HISTORY_LIMIT=${TBOT_HISTORY_LIMIT:--ABSENT--}
     volumes:
       - ${TBOT_DATA_PATH}:/data
     logging:

--- a/env.example
+++ b/env.example
@@ -2,6 +2,4 @@ TBOT_TELEGRAM_KEY=
 TBOT_MASTER_KEY=
 TBOT_CHATGPT_KEY=
 TBOT_ALLOWED_USER_IDS=
-# TBOT_HISTORY_LIMIT controls message history in private chats; set to 0 to disable history
-TBOT_HISTORY_LIMIT=10
 LOG_LEVEL=

--- a/start-compose.sh
+++ b/start-compose.sh
@@ -9,9 +9,5 @@ TBOT_TELEGRAM_KEY=$(jq -r '."tbot-telegram-access-token"' <<<"$SECRET_JSON")
 TBOT_MASTER_KEY=$(jq -r '."tbot-master-key"' <<<"$SECRET_JSON")
 TBOT_CHATGPT_KEY=$(jq -r '."tbot-chatgpt-key"' <<<"$SECRET_JSON")
 TBOT_ALLOWED_USER_IDS=$(jq -r '."tbot-allowed-user-ids"' <<<"$SECRET_JSON")
-
-# Keep up to 10 messages in private chats; set to 0 to disable history
-TBOT_HISTORY_LIMIT=10
-
-export TBOT_TELEGRAM_KEY TBOT_MASTER_KEY TBOT_CHATGPT_KEY TBOT_ALLOWED_USER_IDS TBOT_HISTORY_LIMIT
+export TBOT_TELEGRAM_KEY TBOT_MASTER_KEY TBOT_CHATGPT_KEY TBOT_ALLOWED_USER_IDS
 exec docker compose up -d


### PR DESCRIPTION
## Summary
- store conversation history per project in BoltDB with configurable limits
- add `/history`, `/set-history-limit`, and `/clear-history` commands to manage stored messages
- drop TBOT_HISTORY_LIMIT env var and document new history features

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68990015d2b083239a12d5ba1e270938