### PR TITLE
Enhance history handling with metadata and listing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ go build -o tgptbot ./cmd/tgptbot
 * `/history <projectName>`
   → show current history limit and stored message count.
 
+* `/history-messages <projectName>`
+  → display the stored messages for a project (showing first 30 characters of each).
+
 * `/set-history-limit <projectName>`
   → change how many messages are kept for the project (0 disables history).
 


### PR DESCRIPTION
## Summary
- Include timestamp and author for every message sent to ChatGPT, and record image attachments as special history entries
- Add `/history-messages` command to display stored history snippets

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68990b418a1483238e3950d1fd8f1e57