### PR TITLE
Enable web search tool with location context

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -12,7 +12,9 @@ import (
 	"github.com/go-telegram/bot/models"
 	openai "github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/option"
+	"github.com/openai/openai-go/v2/packages/param"
 	"github.com/openai/openai-go/v2/responses"
+	"github.com/openai/openai-go/v2/shared/constant"
 
 	"telegram-chatgpt-bot/internal/logging"
 	"telegram-chatgpt-bot/internal/storage"
@@ -420,6 +422,20 @@ func HandleUpdate(ctx context.Context, b *tg.Bot, upd *models.Update) {
 		params := responses.ResponseNewParams{
 			Model: openai.ResponsesModel(model),
 			Input: responses.ResponseNewParamsInputUnion{OfInputItemList: inputs},
+			Tools: []responses.ToolUnionParam{
+				{
+					OfWebSearchPreview: &responses.WebSearchToolParam{
+						Type:              responses.WebSearchToolTypeWebSearchPreview,
+						SearchContextSize: responses.WebSearchToolSearchContextSizeHigh,
+						UserLocation: responses.WebSearchToolUserLocationParam{
+							City:     param.NewOpt("Oulu"),
+							Country:  param.NewOpt("FI"),
+							Timezone: param.NewOpt("Europe/Helsinki"),
+							Type:     constant.ValueOf[constant.Approximate](),
+						},
+					},
+				},
+			},
 		}
 		resp, err := client.Responses.New(context.Background(), params)
 		if err != nil && model == defaultModel {


### PR DESCRIPTION
## Summary
- add OpenAI web search tool to ChatGPT requests
- include high search context size and user location for Oulu, Finland

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a015003178832383dbb12f3cecbcbe