### PR TITLE
Add per-project web search, reasoning, and transcription settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ go build -o tgptbot ./cmd/tgptbot
 * `/showrule <projectName>`
   → display the current instruction for a project.
 
+* `/websearch <projectName>`
+  → show the current web search setting for a project.
+
+* `/setwebsearch <projectName>`
+  → configure web search context size for a project.
+
+* `/reasoning <projectName>`
+  → display reasoning effort used for a project.
+
+* `/setreasoning <projectName>`
+  → change reasoning effort for a project.
+
+* `/transcribe <projectName>`
+  → show audio transcription setting for a project.
+
+* `/settranscribe <projectName>`
+  → enable or disable audio transcription for a project.
+
 * `/history <projectName>`
   → show current history limit and stored message count.
 


### PR DESCRIPTION
## Summary
- allow configuring web search, reasoning effort, and audio transcription per project
- store new settings in BoltDB and expose `/websearch`, `/reasoning`, and `/transcribe` commands
- apply project settings when sending requests to ChatGPT, including optional audio transcription

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a060516d2c83239069d8f42b1f72bd