### PR TITLE
Refactor handler for testability and add unit tests

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 
 	tg "github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
 
 	"telegram-chatgpt-bot/internal/crypt"
 	"telegram-chatgpt-bot/internal/handler"
@@ -31,7 +32,9 @@ func Run() {
 		logging.Log.Fatal().Msg("TBOT_TELEGRAM_KEY env var is required")
 	}
 
-	b, err := tg.New(botToken, tg.WithDefaultHandler(handler.HandleUpdate))
+	b, err := tg.New(botToken, tg.WithDefaultHandler(func(ctx context.Context, b *tg.Bot, upd *models.Update) {
+		handler.HandleUpdate(ctx, b, upd)
+	}))
 	if err != nil {
 		logging.Log.Fatal().Err(err).Msg("failed to create bot")
 	}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -66,8 +66,16 @@ func parseAllowedUsers() {
 	}
 }
 
+// Bot wraps the telegram bot methods used by the handler.
+type Bot interface {
+	SendMessage(ctx context.Context, params *tg.SendMessageParams) (*models.Message, error)
+	GetFile(ctx context.Context, params *tg.GetFileParams) (*models.File, error)
+	FileDownloadLink(file *models.File) string
+	EditMessageText(ctx context.Context, params *tg.EditMessageTextParams) (*models.Message, error)
+}
+
 // HandleUpdate processes a Telegram update.
-func HandleUpdate(ctx context.Context, b *tg.Bot, upd *models.Update) {
+func HandleUpdate(ctx context.Context, b Bot, upd *models.Update) {
 	ctx = logging.Context(ctx)
 
 	if upd.CallbackQuery != nil {

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -1,8 +1,16 @@
 package handler
 
 import (
+	"context"
+	"path/filepath"
 	"reflect"
 	"testing"
+
+	tg "github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+
+	"telegram-chatgpt-bot/internal/logging"
+	"telegram-chatgpt-bot/internal/storage"
 )
 
 func TestChatName(t *testing.T) {
@@ -19,5 +27,64 @@ func TestSplitMessage(t *testing.T) {
 	expected := []string{"ab", "cd", "ef"}
 	if !reflect.DeepEqual(parts, expected) {
 		t.Fatalf("splitMessage got %v want %v", parts, expected)
+	}
+}
+
+func TestParseCommand(t *testing.T) {
+	msg := &models.Message{
+		Text: "/newproject proj",
+		Entities: []models.MessageEntity{{
+			Type:   models.MessageEntityTypeBotCommand,
+			Offset: 0,
+			Length: len("/newproject"),
+		}},
+	}
+	cmd, args, ok := parseCommand(msg)
+	if !ok || cmd != "newproject" || args != "proj" {
+		t.Fatalf("parseCommand = %q %q %v", cmd, args, ok)
+	}
+}
+
+type fakeBot struct{ sent []string }
+
+func (f *fakeBot) SendMessage(ctx context.Context, params *tg.SendMessageParams) (*models.Message, error) {
+	f.sent = append(f.sent, params.Text)
+	return &models.Message{ID: 1}, nil
+}
+
+func (f *fakeBot) GetFile(ctx context.Context, params *tg.GetFileParams) (*models.File, error) {
+	return &models.File{}, nil
+}
+
+func (f *fakeBot) FileDownloadLink(file *models.File) string { return "" }
+
+func (f *fakeBot) EditMessageText(ctx context.Context, params *tg.EditMessageTextParams) (*models.Message, error) {
+	return &models.Message{ID: params.MessageID}, nil
+}
+
+func TestHandleUpdateNewProject(t *testing.T) {
+	logging.Init()
+	dir := t.TempDir()
+	if err := storage.Init(filepath.Join(dir, "test.db")); err != nil {
+		t.Fatalf("storage init: %v", err)
+	}
+	b := &fakeBot{}
+	upd := &models.Update{Message: &models.Message{
+		Text: "/newproject demo",
+		Entities: []models.MessageEntity{{
+			Type:   models.MessageEntityTypeBotCommand,
+			Offset: 0,
+			Length: len("/newproject"),
+		}},
+		Chat: models.Chat{ID: 1},
+		From: &models.User{ID: 42},
+	}}
+	HandleUpdate(context.Background(), b, upd)
+	if len(b.sent) != 1 || b.sent[0] != "Project 'demo' registered." {
+		t.Fatalf("unexpected messages: %v", b.sent)
+	}
+	exists, err := storage.ProjectExists("demo")
+	if err != nil || !exists {
+		t.Fatalf("project not saved: %v %v", exists, err)
 	}
 }


### PR DESCRIPTION
## Summary
- abstract telegram Bot interactions behind interface for easier testing
- wrap bot default handler to satisfy new interface
- add tests for command parsing and new project workflow

## Testing
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68a168a9b27483238bd8281f59d6d2c0