### PR TITLE
Add handler unit tests for access control and commands

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -35,6 +35,12 @@ var (
 	pendingTranscribe = map[int64]string{}
 	allowedUsers      map[int64]bool
 	chatGPTKey        string
+
+	// wrappers around storage functions for easier testing
+	saveProject   = storage.SaveProject
+	projectExists = storage.ProjectExists
+	mapTopic      = storage.MapTopic
+	unmapTopic    = storage.UnmapTopic
 )
 
 // Init parses the allowed user ids from the environment.
@@ -113,7 +119,7 @@ func HandleUpdate(ctx context.Context, b Bot, upd *models.Update) {
 				b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, MessageThreadID: topicID, Text: "Usage: /newproject <projectName>"})
 				return
 			}
-			if err := storage.SaveProject(args); err != nil {
+			if err := saveProject(args); err != nil {
 				b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, MessageThreadID: topicID, Text: "Save failed: " + err.Error()})
 				return
 			}
@@ -127,11 +133,11 @@ func HandleUpdate(ctx context.Context, b Bot, upd *models.Update) {
 				b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, MessageThreadID: topicID, Text: "Usage: /settopic <projectName>"})
 				return
 			}
-			if exists, err := storage.ProjectExists(proj); err != nil || !exists {
+			if exists, err := projectExists(proj); err != nil || !exists {
 				b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, MessageThreadID: topicID, Text: "Project not found."})
 				return
 			}
-			if err := storage.MapTopic(chatID, topicID, proj); err != nil {
+			if err := mapTopic(chatID, topicID, proj); err != nil {
 				b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, MessageThreadID: topicID, Text: "Failed to map topic: " + err.Error()})
 				return
 			}
@@ -144,7 +150,7 @@ func HandleUpdate(ctx context.Context, b Bot, upd *models.Update) {
 				b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, MessageThreadID: topicID, Text: "Must be in a topic thread."})
 				return
 			}
-			if err := storage.UnmapTopic(chatID, topicID); err != nil {
+			if err := unmapTopic(chatID, topicID); err != nil {
 				b.SendMessage(ctx, &tg.SendMessageParams{ChatID: chatID, MessageThreadID: topicID, Text: "Failed to unmap: " + err.Error()})
 				return
 			}

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -2,8 +2,10 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	tg "github.com/go-telegram/bot"
@@ -62,7 +64,106 @@ func (f *fakeBot) EditMessageText(ctx context.Context, params *tg.EditMessageTex
 	return &models.Message{ID: params.MessageID}, nil
 }
 
-func TestHandleUpdateNewProject(t *testing.T) {
+func TestHandleUpdate_IgnoresCallback(t *testing.T) {
+	b := &fakeBot{}
+	upd := &models.Update{CallbackQuery: &models.CallbackQuery{}, Message: &models.Message{Text: "hi"}}
+	HandleUpdate(context.Background(), b, upd)
+	if len(b.sent) != 0 {
+		t.Fatalf("expected no messages, got %v", b.sent)
+	}
+}
+
+func TestHandleUpdate_NoMessage(t *testing.T) {
+	b := &fakeBot{}
+	upd := &models.Update{}
+	HandleUpdate(context.Background(), b, upd)
+	if len(b.sent) != 0 {
+		t.Fatalf("expected no messages, got %v", b.sent)
+	}
+}
+
+func TestHandleUpdate_AllowedUsers(t *testing.T) {
+	logging.Init()
+	allowedUsers = map[int64]bool{1: true}
+	t.Cleanup(func() { allowedUsers = nil })
+
+	t.Run("unauthorized", func(t *testing.T) {
+		b := &fakeBot{}
+		called := false
+		orig := saveProject
+		saveProject = func(name string) error { called = true; return nil }
+		defer func() { saveProject = orig }()
+		upd := &models.Update{Message: &models.Message{
+			Text:     "/newproject demo",
+			Entities: []models.MessageEntity{{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: len("/newproject")}},
+			Chat:     models.Chat{ID: 1},
+			From:     &models.User{ID: 2},
+		}}
+		HandleUpdate(context.Background(), b, upd)
+		if called {
+			t.Fatal("saveProject should not be called")
+		}
+		if len(b.sent) != 1 || !strings.Contains(b.sent[0], "configured to work only") {
+			t.Fatalf("unexpected messages: %v", b.sent)
+		}
+	})
+
+	t.Run("authorized", func(t *testing.T) {
+		b := &fakeBot{}
+		called := false
+		orig := saveProject
+		saveProject = func(name string) error { called = true; return nil }
+		defer func() { saveProject = orig }()
+		upd := &models.Update{Message: &models.Message{
+			Text:     "/newproject ok",
+			Entities: []models.MessageEntity{{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: len("/newproject")}},
+			Chat:     models.Chat{ID: 1},
+			From:     &models.User{ID: 1},
+		}}
+		HandleUpdate(context.Background(), b, upd)
+		if !called {
+			t.Fatal("saveProject should be called")
+		}
+		if len(b.sent) != 1 || b.sent[0] != "Project 'ok' registered." {
+			t.Fatalf("unexpected messages: %v", b.sent)
+		}
+	})
+}
+
+func TestHandleUpdateNewProject_MissingName(t *testing.T) {
+	logging.Init()
+	b := &fakeBot{}
+	upd := &models.Update{Message: &models.Message{
+		Text:     "/newproject",
+		Entities: []models.MessageEntity{{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: len("/newproject")}},
+		Chat:     models.Chat{ID: 1},
+		From:     &models.User{ID: 1},
+	}}
+	HandleUpdate(context.Background(), b, upd)
+	if len(b.sent) != 1 || b.sent[0] != "Usage: /newproject <projectName>" {
+		t.Fatalf("unexpected messages: %v", b.sent)
+	}
+}
+
+func TestHandleUpdateNewProject_SaveError(t *testing.T) {
+	logging.Init()
+	b := &fakeBot{}
+	orig := saveProject
+	saveProject = func(name string) error { return fmt.Errorf("boom") }
+	defer func() { saveProject = orig }()
+	upd := &models.Update{Message: &models.Message{
+		Text:     "/newproject demo",
+		Entities: []models.MessageEntity{{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: len("/newproject")}},
+		Chat:     models.Chat{ID: 1},
+		From:     &models.User{ID: 1},
+	}}
+	HandleUpdate(context.Background(), b, upd)
+	if len(b.sent) != 1 || !strings.Contains(b.sent[0], "Save failed: boom") {
+		t.Fatalf("unexpected messages: %v", b.sent)
+	}
+}
+
+func TestHandleUpdateNewProject_Success(t *testing.T) {
 	logging.Init()
 	dir := t.TempDir()
 	if err := storage.Init(filepath.Join(dir, "test.db")); err != nil {
@@ -87,4 +188,130 @@ func TestHandleUpdateNewProject(t *testing.T) {
 	if err != nil || !exists {
 		t.Fatalf("project not saved: %v %v", exists, err)
 	}
+}
+
+func TestHandleUpdateSetTopic(t *testing.T) {
+	logging.Init()
+	t.Run("usage", func(t *testing.T) {
+		b := &fakeBot{}
+		upd := &models.Update{Message: &models.Message{
+			Text:     "/settopic",
+			Entities: []models.MessageEntity{{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: len("/settopic")}},
+			Chat:     models.Chat{ID: 1},
+			From:     &models.User{ID: 1},
+		}}
+		HandleUpdate(context.Background(), b, upd)
+		if len(b.sent) != 1 || b.sent[0] != "Usage: /settopic <projectName>" {
+			t.Fatalf("unexpected messages: %v", b.sent)
+		}
+	})
+
+	t.Run("project not found", func(t *testing.T) {
+		b := &fakeBot{}
+		origPE := projectExists
+		projectExists = func(name string) (bool, error) { return false, nil }
+		defer func() { projectExists = origPE }()
+		upd := &models.Update{Message: &models.Message{
+			Text:     "/settopic demo",
+			Entities: []models.MessageEntity{{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: len("/settopic")}},
+			Chat:     models.Chat{ID: 1},
+			From:     &models.User{ID: 1},
+		}}
+		HandleUpdate(context.Background(), b, upd)
+		if len(b.sent) != 1 || b.sent[0] != "Project not found." {
+			t.Fatalf("unexpected messages: %v", b.sent)
+		}
+	})
+
+	t.Run("map error", func(t *testing.T) {
+		b := &fakeBot{}
+		origPE := projectExists
+		origMT := mapTopic
+		projectExists = func(name string) (bool, error) { return true, nil }
+		mapTopic = func(chatID int64, topicID int, project string) error { return fmt.Errorf("boom") }
+		defer func() { projectExists = origPE; mapTopic = origMT }()
+		upd := &models.Update{Message: &models.Message{
+			Text:     "/settopic demo",
+			Entities: []models.MessageEntity{{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: len("/settopic")}},
+			Chat:     models.Chat{ID: 1},
+			From:     &models.User{ID: 1},
+		}}
+		HandleUpdate(context.Background(), b, upd)
+		if len(b.sent) != 1 || !strings.Contains(b.sent[0], "Failed to map topic: boom") {
+			t.Fatalf("unexpected messages: %v", b.sent)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		b := &fakeBot{}
+		origPE := projectExists
+		origMT := mapTopic
+		projectExists = func(name string) (bool, error) { return true, nil }
+		mapTopic = func(chatID int64, topicID int, project string) error { return nil }
+		defer func() { projectExists = origPE; mapTopic = origMT }()
+		upd := &models.Update{Message: &models.Message{
+			Text:            "/settopic demo",
+			Entities:        []models.MessageEntity{{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: len("/settopic")}},
+			Chat:            models.Chat{ID: 1},
+			MessageThreadID: 2,
+			From:            &models.User{ID: 1},
+		}}
+		HandleUpdate(context.Background(), b, upd)
+		if len(b.sent) != 1 || b.sent[0] != "Topic mapped to project 'demo'." {
+			t.Fatalf("unexpected messages: %v", b.sent)
+		}
+	})
+}
+
+func TestHandleUpdateUnsetTopic(t *testing.T) {
+	logging.Init()
+	t.Run("usage", func(t *testing.T) {
+		b := &fakeBot{}
+		upd := &models.Update{Message: &models.Message{
+			Text:     "/unsettopic",
+			Entities: []models.MessageEntity{{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: len("/unsettopic")}},
+			Chat:     models.Chat{ID: 1},
+			From:     &models.User{ID: 1},
+		}}
+		HandleUpdate(context.Background(), b, upd)
+		if len(b.sent) != 1 || b.sent[0] != "Must be in a topic thread." {
+			t.Fatalf("unexpected messages: %v", b.sent)
+		}
+	})
+
+	t.Run("unmap error", func(t *testing.T) {
+		b := &fakeBot{}
+		orig := unmapTopic
+		unmapTopic = func(chatID int64, topicID int) error { return fmt.Errorf("boom") }
+		defer func() { unmapTopic = orig }()
+		upd := &models.Update{Message: &models.Message{
+			Text:            "/unsettopic",
+			Entities:        []models.MessageEntity{{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: len("/unsettopic")}},
+			Chat:            models.Chat{ID: 1},
+			MessageThreadID: 2,
+			From:            &models.User{ID: 1},
+		}}
+		HandleUpdate(context.Background(), b, upd)
+		if len(b.sent) != 1 || !strings.Contains(b.sent[0], "Failed to unmap: boom") {
+			t.Fatalf("unexpected messages: %v", b.sent)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		b := &fakeBot{}
+		orig := unmapTopic
+		unmapTopic = func(chatID int64, topicID int) error { return nil }
+		defer func() { unmapTopic = orig }()
+		upd := &models.Update{Message: &models.Message{
+			Text:            "/unsettopic",
+			Entities:        []models.MessageEntity{{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: len("/unsettopic")}},
+			Chat:            models.Chat{ID: 1},
+			MessageThreadID: 2,
+			From:            &models.User{ID: 1},
+		}}
+		HandleUpdate(context.Background(), b, upd)
+		if len(b.sent) != 1 || b.sent[0] != "Topic unmapped." {
+			t.Fatalf("unexpected messages: %v", b.sent)
+		}
+	})
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -64,6 +64,16 @@ func Init(path string) error {
 	})
 }
 
+// Close releases the underlying database. Primarily used in tests.
+func Close() error {
+	if db == nil {
+		return nil
+	}
+	err := db.Close()
+	db = nil
+	return err
+}
+
 // SaveProject registers a project name without any associated API key.
 func SaveProject(name string) error {
 	return db.Update(func(tx *bolt.Tx) error {


### PR DESCRIPTION
## Summary
- add wrappers for storage functions and Close helper for tests
- cover handler early returns, allowed-user checks, and command success/error paths

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a238548874832395738a7dbc330ac4