### PR TITLE
Add CI workflow and release instructions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go test ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Telegram–ChatGPT Bot in Go
 
+[![Tests](https://github.com/OWNER/ai-telegram-link/actions/workflows/test.yml/badge.svg)](https://github.com/OWNER/ai-telegram-link/actions/workflows/test.yml)
+
 This tool is implemented using ChatGPT.
 
 ## Prerequisites
@@ -169,3 +171,25 @@ docker compose up -d
 ```
 
 The Bolt database will be stored under `data/` on the host.
+
+## Testing
+
+Run the unit tests locally:
+
+```bash
+go test ./...
+```
+
+Tests also run automatically via GitHub Actions on every push, pull request, and tag. The badge at the top of this README links to the latest results.
+
+## Releasing
+
+1. Ensure tests pass locally and in CI.
+2. Create and push an annotated tag:
+
+   ```bash
+   git tag -a v0.1.0 -m "Release v0.1.0"
+   git push origin v0.1.0
+   ```
+
+3. Draft a GitHub release for the tag. The test status for the tagged release will be visible on the release page.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `go test`
- show test status badge and testing instructions in README
- document tagging process for releases

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a23b130ea08323b26b4635646dba07