### PR TITLE
Add ChatGPT progress tracking and helper tests

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -73,6 +73,7 @@ var (
 		return tResp.Text, nil
 	}
 	httpGetFunc = http.Get
+	newTicker   = time.NewTicker
 )
 
 // Init parses the allowed user ids from the environment.
@@ -695,7 +696,7 @@ func HandleUpdate(ctx context.Context, b Bot, upd *models.Update) {
 		resultCh <- gptResult{reply: reply}
 	}()
 
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := newTicker(10 * time.Second)
 	start := time.Now()
 	var res gptResult
 	for {


### PR DESCRIPTION
## Summary
- Add injectable ticker and comprehensive tests for ChatGPT progress, web search tool selection, reasoning effort, and error handling
- Verify long response chunking, history persistence, and helper utilities like command parsing and name normalization

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bab271ffec83238bf5d663a050a6c8